### PR TITLE
Fix StreamEvent,next reference leak when update in-memory table

### DIFF
--- a/modules/siddhi-core/src/main/java/io/siddhi/core/util/collection/operator/IndexOperator.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/util/collection/operator/IndexOperator.java
@@ -172,13 +172,16 @@ public class IndexOperator implements Operator {
                 }
                 storeEvents.add(toUpdateEventChunk);
             } else {
-                while (foundEventChunk.hasNext()) {
-                    StreamEvent streamEvent = foundEventChunk.next();
-                    streamEvent.setNext(null); // to make the chained state back to normal
+                StreamEvent first = foundEventChunk.getFirst();
+                while (first != null) {
+                    StreamEvent streamEvent = first;
                     for (Map.Entry<Integer, ExpressionExecutor> entry :
                             compiledUpdateSet.getExpressionExecutorMap().entrySet()) {
                         streamEvent.setOutputData(entry.getValue().execute(overwritingOrAddingEvent), entry.getKey());
                     }
+                    StreamEvent next = first.getNext();
+                    first.setNext(null); // to make the chained state back to normal
+                    first = next;
                 }
             }
         }


### PR DESCRIPTION
It is the root cause of  CPU cost by getLastEvent while add/remove event in ComplexEventChunk
https://github.com/siddhi-io/siddhi/issues/1270

## Purpose
> Resolve https://github.com/siddhi-io/siddhi/issues/1270

## Goals
> It is a bug when try to reset the updated stream events retrieved from find method, as in-memory table did not clone event, so if the next was not reset, it will cause problem.

## Approach
> It is a simple fix.

## Release note
> Fix bug for potential dead loop caused by in-memory table update. this only happen when update in-memory table not via primary key.

## Documentation
> N/A
## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Test environment
> N/A
 
